### PR TITLE
Add MusicAlbum and Genre classes

### DIFF
--- a/app/genre.rb
+++ b/app/genre.rb
@@ -1,0 +1,3 @@
+class Genre
+  
+end

--- a/app/genre.rb
+++ b/app/genre.rb
@@ -1,9 +1,14 @@
 class Genre
-  attr_reader :id
-  
+  attr_reader :id, :name, :items
+
   def initialize(name, id = Random.rand(1..100_000))
     @id = id
     @name = name
     @items = []
+  end
+
+  def add_item(item)
+    @items.push(item)
+    item.add_genre = self
   end
 end

--- a/app/genre.rb
+++ b/app/genre.rb
@@ -1,3 +1,9 @@
 class Genre
+  attr_reader :id
   
+  def initialize(name, id = Random.rand(1..100_000))
+    @id = id
+    @name = name
+    @items = []
+  end
 end

--- a/app/music_album.rb
+++ b/app/music_album.rb
@@ -1,5 +1,10 @@
 require_relative './item'
 
 class MusicAlbum < item
-  
+  attr_accessor :on_spotify
+
+  def initialize(name, publish_date, archived = false, on_spotify = false, id = Random.rand(1..100_000))
+    super(name, publish_date, archived, id)
+    @on_spotify = on_spotify
+  end
 end

--- a/app/music_album.rb
+++ b/app/music_album.rb
@@ -1,0 +1,5 @@
+require_relative './item'
+
+class MusicAlbum < item
+  
+end

--- a/app/music_album.rb
+++ b/app/music_album.rb
@@ -7,4 +7,10 @@ class MusicAlbum < item
     super(name, publish_date, archived, id)
     @on_spotify = on_spotify
   end
+
+  private
+
+  def can_be_archived?
+    super && @on_spotify
+  end
 end

--- a/app/music_album.rb
+++ b/app/music_album.rb
@@ -3,10 +3,12 @@ require_relative './item'
 class MusicAlbum < item
   attr_accessor :on_spotify
 
+  # rubocop:disable Style/OptionalBooleanParameter
   def initialize(name, publish_date, archived = false, on_spotify = false, id = Random.rand(1..100_000))
     super(name, publish_date, archived, id)
     @on_spotify = on_spotify
   end
+  # rubocop:enable Style/OptionalBooleanParameter
 
   private
 


### PR DESCRIPTION
## Add MusicAlbum and Genre classes
### In this pull request, I have worked on the following;
✅ created the `MusicAlbum` class
✅ created the `Genre` class with an association to the `Item` class
✅ defined all `MusicAlbum` properties visible in the UML diagram
✅ defined all `Genre` class properties visible in the UML diagram
✅ Implemented the following methods:

- `add_item` method in the `Genre` class
- `can_be_archived?` method in the `MusicAlbum` class

✅ Fixed errors spotted by linters